### PR TITLE
Simplify example Python client

### DIFF
--- a/vloed.py
+++ b/vloed.py
@@ -264,6 +264,10 @@ class PixelVloedClient(object):
 def NewMessage():
   """Creates a new message with the correct max size, rgb mode and version"""
   message = MaxSizeList(MAX_PIXELS+2)
+  InitMessage(message)
+  return message
+
+def InitMessage(message):
   message.append(SetRGBAMode(False))
   message.append(SetVersionBit())
   return message


### PR DESCRIPTION
 - Move handling packet size out of RandomFill
 - Adds an InitMessage function to vloed.py to set message header
   without using NewMessage
 - No more exceptions in normal program flow!

Code was tested manually by making RandomFill temporarily return MAX_PIXELS*10 pixels