### PR TITLE
Simplify example Python client

### DIFF
--- a/client.py
+++ b/client.py
@@ -9,7 +9,7 @@ __version__ = 0.3
 __author__ = "Jan Klopper <jan@underdark.nl>"
 
 import random
-from vloed import PixelVloedClient, InitMessage, RGBPixel, MAX_PIXELS
+from vloed import PixelVloedClient, Packet, RGBPixel, MAX_PIXELS
 
 def RandomFill(pixels, width, height):
   """Generates a random number of pixels with a random color"""
@@ -34,22 +34,17 @@ def RunClient(options):
 
   # loop the effect until we cancel by pressing ctrl+c / exit the program
   while True:
-    pixels = [] # list to store the pixels we want to send
+
+    # packet will automatically send its pixels if gets to the maximum pixel length
+    pixels = Packet(client)
 
     # add some pixels to the output with our functions
     # the width/height are read from the client's config
     RandomFill(pixels, client.width, client.height)
 
-    # send our pixels in packets including a message header and less than
-    # MAX_PIXELS pixels
-    for part in SplitList(MAX_PIXELS, pixels):
-      packet = InitMessage([]) + part
-      client.SendPacket(''.join(packet))
+    # send whatever pixels are left in the packet
+    pixels.flush()
 
-def SplitList(max_size, lis):
-    """Splits a list into equal-sized chunks"""
-    for i in xrange(0, len(lis), max_size):
-        yield lis[i:i+max_size]
 
 if __name__ == '__main__':
   # if this script is called from the command line, and thus not imported

--- a/vloed.py
+++ b/vloed.py
@@ -264,6 +264,10 @@ class PixelVloedClient(object):
 def NewMessage():
   """Creates a new message with the correct max size, rgb mode and version"""
   message = MaxSizeList(MAX_PIXELS+2)
+  InitMessage(message)
+  return message
+
+def InitMessage(message):
   message.append(SetRGBAMode(False))
   message.append(SetVersionBit())
   return message


### PR DESCRIPTION
Improvement over #20. No longer has the drawback of only sending packets after all drawing is done. Also even simpler client since length checking and packet sending is hidden in the Packet class, implemented in vloed.py